### PR TITLE
Schema extension logic added

### DIFF
--- a/.github/workflows/schema_validator.yaml
+++ b/.github/workflows/schema_validator.yaml
@@ -27,7 +27,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: pip install -r src/requirements.txt
+        run: pip install -r requirements.txt
 
       - name: Schema validation
         id: schema

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,0 +1,31 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9']
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install -r src/requirements.txt
+
+
+      - name: Run test
+        run: PYTHONPATH=./src/scripts:$PYTHONPATH python -m unittest discover -s src -p '*_test.py'

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -24,7 +24,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: pip install -r src/requirements.txt
+        run: pip install -r requirements.txt
 
 
       - name: Run test

--- a/BICAN_extension.json
+++ b/BICAN_extension.json
@@ -1,7 +1,7 @@
 {
     "allOf": [
       {
-        "$ref": "https://raw.githubusercontent.com/cellannotation/cell-annotation-schema/main/general_schema.json"
+        "$ref": "./general_schema.json"
       }
     ],
 

--- a/BICAN_extension.json
+++ b/BICAN_extension.json
@@ -51,5 +51,13 @@
         }
       }
     }
+  },
+  "properties":{
+    "transferred_annotations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Annotation_transfer"
+      }
+    }
   }
 }

--- a/CAP_extension.json
+++ b/CAP_extension.json
@@ -1,7 +1,7 @@
 {
   "allOf": [
       {
-        "$ref": "https://raw.githubusercontent.com/cellannotation/cell-annotation-schema/main/general_schema.json"
+        "$ref": "./general_schema.json"
       }
     ],
 

--- a/CAP_extension.json
+++ b/CAP_extension.json
@@ -1,4 +1,10 @@
 {
+  "allOf": [
+      {
+        "$ref": "https://raw.githubusercontent.com/cellannotation/cell-annotation-schema/main/general_schema.json"
+      }
+    ],
+
   "required": [
     "cellannotation_schema_version",
     "cellannotation_timestamp",

--- a/docs/schema-extension.md
+++ b/docs/schema-extension.md
@@ -1,0 +1,65 @@
+# Extending Schemas
+
+This project introduces a schema extension mechanism. 
+
+Extension schemas can now import base schemas using the `allOf` keyword, either through an absolute URL like:
+
+```json
+"allOf": [
+      {"$ref": "https://raw.githubusercontent.com/cellannotation/cell-annotation-schema/main/general_schema.json" }
+    ],
+```
+Or, you can use relative paths for referencing the base schema:
+```json
+"allOf": [
+      {"$ref": "./general_schema.json" }
+    ],
+```
+These paths are relative to the extension schema file's location.
+
+To make use of these schema extension capabilities `schema_manager.load` should be used instead of `json.loads` while reading the schema files. `schema_manager.load` operation will merge all properties of the imported schema to the current schema and will resolve any conflicts.
+
+Schema merging operation is a recursive operation and supports importing multiple base schemas. Even base schemas can import other schemas.
+
+_NOTE: Currently we don`t have mechanisms to detect and prevent cyclic imports. So, please make sure you don't cause one._
+
+## Conflict resolution
+
+A conflict occurs when extension schema re-declares a base property with a different configuration. Such as, for a given base property:
+
+```json
+    "age": {
+      "description": "Age in years which must be equal to or greater than zero.",
+      "type": "integer",
+      "minimum": 0
+    }
+```
+if extension declares `age` with different settings, a conflict occurs.
+```json
+    "age": {
+      "type": "string",
+      "description": "Age of the person."
+    }
+```
+By default, both of these should be satisfied to have a valid json data, which is impossible.
+
+To overcome conflicts, we provide two conflict resolution strategies. These strategies ensure that extension schemas work seamlessly with the base schema, with the default strategy being the "ExtensionStrategy."
+
+- **ExtensionStrategy**: In this mode, extension schema can introduce new properties without overriding the base schema. In the event of a conflict, the declarations from the base schema take precedence, and `required` property declarations are merged.
+- **OverrideStrategy**: In this strategy, extension schemas have the flexibility to both add new properties and override existing properties in the base schema. When conflicts arise, the declarations from the extension schema will override those in the base schema, while `required` property declarations will be sourced from the extending schema.
+
+If there are not any conflicts, these two strategies produces the same output.
+
+## Catalog files
+
+While extension schemas commonly should reference to base schemas via web URLs (or PURLs), catalog files can be invaluable for development and testing purposes. They enable the redirection of web URLs to local schema files, facilitating a smooth development and testing workflow.
+
+An example catalog file is located at [src/catalog.yaml](src/catalog.yaml)
+
+```yaml
+https://raw.githubusercontent.com/cellannotation/cell-annotation-schema/main/general_schema.json: ../general_schema.json
+```
+
+Pointed local file paths are relative to the location of the `catalog.yaml` file itself. Hence, in this example, it is relative to `{root_folder}/src/catalog.yaml` which resolves to `{root_folder}/src/catalog.yaml`.
+
+A basic caching mechanism added for catalog files to prevent repetitive file read operations and accordingly increase performance.

--- a/docs/schema-extension.md
+++ b/docs/schema-extension.md
@@ -60,6 +60,6 @@ An example catalog file is located at [src/catalog.yaml](src/catalog.yaml)
 https://raw.githubusercontent.com/cellannotation/cell-annotation-schema/main/general_schema.json: ../general_schema.json
 ```
 
-Pointed local file paths are relative to the location of the `catalog.yaml` file itself. Hence, in this example, it is relative to `{root_folder}/src/catalog.yaml` which resolves to `{root_folder}/catalog.yaml`.
+Pointed local file paths are relative to the location of the `catalog.yaml` file itself. Hence, in this example, it is relative to `{root_folder}/src/catalog.yaml` which resolves to `{root_folder}/general_schema.json`.
 
 A basic caching mechanism added for catalog files to prevent repetitive file read operations and accordingly increase performance.

--- a/docs/schema-extension.md
+++ b/docs/schema-extension.md
@@ -43,7 +43,7 @@ if extension declares `age` with different settings, a conflict occurs.
 ```
 By default, both of these should be satisfied to have a valid json data, which is impossible.
 
-To overcome conflicts, we provide two conflict resolution strategies. These strategies ensure that extension schemas work seamlessly with the base schema, with the default strategy being the "ExtensionStrategy."
+To overcome conflicts, we provide two conflict resolution strategies. These strategies ensure that extension schemas work seamlessly with the base schema, with the default strategy being the `ExtensionStrategy`.
 
 - **ExtensionStrategy**: In this mode, extension schema can introduce new properties without overriding the base schema. In the event of a conflict, the declarations from the base schema take precedence, and `required` property declarations are merged.
 - **OverrideStrategy**: In this strategy, extension schemas have the flexibility to both add new properties and override existing properties in the base schema. When conflicts arise, the declarations from the extension schema will override those in the base schema, while `required` property declarations will be sourced from the extending schema.
@@ -60,6 +60,6 @@ An example catalog file is located at [src/catalog.yaml](src/catalog.yaml)
 https://raw.githubusercontent.com/cellannotation/cell-annotation-schema/main/general_schema.json: ../general_schema.json
 ```
 
-Pointed local file paths are relative to the location of the `catalog.yaml` file itself. Hence, in this example, it is relative to `{root_folder}/src/catalog.yaml` which resolves to `{root_folder}/src/catalog.yaml`.
+Pointed local file paths are relative to the location of the `catalog.yaml` file itself. Hence, in this example, it is relative to `{root_folder}/src/catalog.yaml` which resolves to `{root_folder}/catalog.yaml`.
 
 A basic caching mechanism added for catalog files to prevent repetitive file read operations and accordingly increase performance.

--- a/examples/BICAN_schema_specific_examples/Silletti_annotation_transfer.json
+++ b/examples/BICAN_schema_specific_examples/Silletti_annotation_transfer.json
@@ -1,6 +1,6 @@
 {
-  "author": "Kimberly Siletti",
-  "labelsets": [
+  "author_name": "Kimberley Siletti",
+  "labelset": [
     {
       "cellannotation_setname": "Subtype",
       "cell_label": "INT-VIP",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 jsonschema==4.4.0
 ordered-set==4.1.0
 deepmerge==1.1.0
+ruamel.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+jsonschema==4.4.0
+ordered-set==4.1.0
+deepmerge==1.1.0

--- a/src/catalog.yaml
+++ b/src/catalog.yaml
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/cellannotation/cell-annotation-schema/main/general_schema.json: ../general_schema.json

--- a/src/json_utils.py
+++ b/src/json_utils.py
@@ -1,0 +1,68 @@
+import os
+import json
+import warnings
+
+from urllib.request import urlopen
+
+
+def get_json(path, referrer_path=None):
+    """
+    Reads json from the given path. Path can be a relative or absolute file path or a web URL.
+    :param path: path of the json.
+    :param referrer_path: (optional) absolute path of the referring schema. Used for resolving the relative paths.
+    """
+    if is_web_url(path):
+        return get_json_from_url(path)
+    else:
+        return get_json_from_file(get_absolute_path(path, referrer_path))
+
+
+def get_absolute_path(path_to_resolve, referrer_abs_path):
+    """
+    Creates an absolute path from the given path relative to the referrer absolute path
+    :param path_to_resolve: relative path to resolve
+    :param referrer_abs_path: absolute path of the referrer
+    :return absolute path
+    """
+    if is_web_url(path_to_resolve) or referrer_abs_path is None:
+        return path_to_resolve
+
+    if is_web_url(referrer_abs_path):
+        warnings.warn("Schema read from the web ({}) cannot import from relative path ({})."
+                      .format(referrer_abs_path, path_to_resolve))
+
+    if os.path.isfile(path_to_resolve):
+        return path_to_resolve
+    else:
+        # process relative path
+        referrer_folder = os.path.dirname(os.path.abspath(referrer_abs_path))
+        abs_path = os.path.join(referrer_folder, path_to_resolve)
+        if os.path.isfile(abs_path):
+            return abs_path
+        else:
+            warnings.warn("File not found: " + path_to_resolve)
+
+
+
+
+def is_web_url(path):
+    return str(path).startswith("http://") or str(path).startswith("https://")
+
+
+def get_json_from_url(url):
+    """Loads JSOn from web URL."""
+    return json.loads(urlopen(url).read())
+
+
+def get_json_from_file(filename):
+    """Loads JSON from a file."""
+    try:
+        with open(filename, "r") as f:
+            fc = f.read()
+        return json.loads(fc)
+    except FileNotFoundError:
+        warnings.warn("File not found: " + filename)
+    except IOError as exc:
+        warnings.warn("I/O error while opening " + filename + ": " + str(exc))
+    except json.JSONDecodeError as exc:
+        warnings.warn("Failed to parse JSON in " + filename + ": " + str(exc))

--- a/src/json_utils.py
+++ b/src/json_utils.py
@@ -3,28 +3,42 @@ import json
 import warnings
 
 from urllib.request import urlopen
+from ruamel.yaml import YAML
+
+# cache of catalog files for performance reasons
+catalog_cache = dict()
 
 
-def get_json(path, referrer_path=None):
+def get_json(path, referrer_path=None, catalog_file=None):
     """
     Reads json from the given path. Path can be a relative or absolute file path or a web URL.
     :param path: path of the json.
     :param referrer_path: (optional) absolute path of the referring schema. Used for resolving the relative paths.
+    :param catalog_file: catalog file to locally resolve web urls. This is useful for local development and testing.
+    Paths in the catalog file are relative to the catalog file itself.
     """
-    if is_web_url(path):
-        return get_json_from_url(path)
+    resolved_path = resolve_path(path, referrer_path, catalog_file)
+    if is_web_url(resolved_path):
+        return get_json_from_url(resolved_path)
     else:
-        return get_json_from_file(get_absolute_path(path, referrer_path))
+        return get_json_from_file(resolved_path)
 
 
-def get_absolute_path(path_to_resolve, referrer_abs_path):
+def resolve_path(path_to_resolve, referrer_abs_path, catalog_file):
     """
-    Creates an absolute path from the given path relative to the referrer absolute path
+    Resolves the give path to its actual location. If given path is already an absolute path, returns it directly.
+    If path is relative, resolves it based on referrer's path.
+    If a catalog file is provided, resolves web urls accordingly.
     :param path_to_resolve: relative path to resolve
     :param referrer_abs_path: absolute path of the referrer
-    :return absolute path
+    :param catalog_file: catalog file to locally resolve web urls. This is useful for local development and testing.
+    Paths in the catalog file are relative to the catalog file itself.
+    :return: absolute path
     """
-    if is_web_url(path_to_resolve) or referrer_abs_path is None:
+    if is_web_url(path_to_resolve):
+        return resolve_via_catalog(path_to_resolve, catalog_file)
+
+    if referrer_abs_path is None:
         return path_to_resolve
 
     if is_web_url(referrer_abs_path):
@@ -40,12 +54,43 @@ def get_absolute_path(path_to_resolve, referrer_abs_path):
         if os.path.isfile(abs_path):
             return abs_path
         else:
-            warnings.warn("File not found: " + path_to_resolve)
+            warnings.warn("File not found: '{}' at its resolved location: '{}'".format(path_to_resolve, abs_path))
 
 
+def resolve_via_catalog(web_url, catalog_file):
+    """
+    Tries to resolve given web url from the catalog. If cannot find in the catalog, returns as is.
+    """
+    if catalog_file is not None:
+        catalog_obj = read_catalog(catalog_file)
+        if web_url in catalog_obj:
+            relative_path = catalog_obj[web_url]
+            return resolve_path(relative_path, catalog_file, None)
+    return web_url
+
+
+def read_catalog(catalog_file):
+    """
+    Reads the catalog file from the given path and caches it. If already in the cache, returns the cached obj.
+    :param catalog_file: path of the catalog file
+    :return: catalog object
+    """
+    if catalog_file in catalog_cache:
+        catalog_obj = catalog_cache[catalog_file]
+    else:
+        ryaml = YAML(typ='safe')
+        with open(catalog_file) as stream:
+            catalog_obj = ryaml.load(stream)
+            catalog_cache[catalog_file] = catalog_obj
+    return catalog_obj
 
 
 def is_web_url(path):
+    """
+    Checks if the given path is a web URL.
+    :param path: path reference to check
+    :return: True if a web URL, False otherwise
+    """
     return str(path).startswith("http://") or str(path).startswith("https://")
 
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,0 @@
-jsonschema==4.4.0
-ordered-set==4.1.0

--- a/src/schema_manager.py
+++ b/src/schema_manager.py
@@ -1,0 +1,33 @@
+from schema_merger import OverrideStrategy, ExtensionStrategy
+from json_utils import get_json, get_absolute_path
+
+
+merge_strategy = OverrideStrategy()
+
+
+def load(path: str, strategy=merge_strategy, referrer_path=None) -> dict:
+    """
+    Loads the schema json object from the given path. In addition to vanilla schema loading, recursively merges declared
+     base schemas according to the declared import strategy (extend/override)
+    :param path: file path of the schema
+    :param strategy: (optional) schema merge strategy (extend/override)
+    :param referrer_path: (optional) path of the referring schema. Used for resolving the relative paths.
+    """
+    # TODO add cyclic import prevention logic
+    schema = get_json(path, referrer_path)
+
+    merged_base = None
+    if "allOf" in schema:
+        for base_schema_declaration in schema["allOf"]:
+            base_ref = base_schema_declaration["$ref"]
+            abs_path = get_absolute_path(path, referrer_path)
+            if merged_base is None:
+                merged_base = load(base_ref, strategy, abs_path)
+            else:
+                merged_base = strategy.merge(merged_base, load(base_ref, strategy, abs_path))
+
+    if merged_base is not None:
+        schema = strategy.merge(merged_base, schema)
+        del schema['allOf']
+
+    return schema

--- a/src/schema_manager.py
+++ b/src/schema_manager.py
@@ -1,30 +1,33 @@
 from schema_merger import OverrideStrategy, ExtensionStrategy
-from json_utils import get_json, get_absolute_path
+from json_utils import get_json, resolve_path
 
 
-merge_strategy = OverrideStrategy()
+merge_strategy = ExtensionStrategy()
 
 
-def load(path: str, strategy=merge_strategy, referrer_path=None) -> dict:
+def load(path: str, strategy=merge_strategy, referrer_path=None, catalog_file=None) -> dict:
     """
     Loads the schema json object from the given path. In addition to vanilla schema loading, recursively merges declared
-     base schemas according to the declared import strategy (extend/override)
-    :param path: file path of the schema
-    :param strategy: (optional) schema merge strategy (extend/override)
+     base schemas according to the specified import strategy (extend/override).
+    :param path: file path or web url of the schema
+    :param strategy: (optional) schema merge strategy (extend/override). Default strategy is extension
     :param referrer_path: (optional) path of the referring schema. Used for resolving the relative paths.
+    :param catalog_file: catalog file to locally resolve web urls. This is useful for local development and testing.
+    Paths in the catalog file are relative to the catalog file itself.
+    :return: merged schema
     """
     # TODO add cyclic import prevention logic
-    schema = get_json(path, referrer_path)
+    schema = get_json(path, referrer_path, catalog_file)
 
     merged_base = None
     if "allOf" in schema:
         for base_schema_declaration in schema["allOf"]:
             base_ref = base_schema_declaration["$ref"]
-            abs_path = get_absolute_path(path, referrer_path)
+            abs_path = resolve_path(path, referrer_path, catalog_file)
             if merged_base is None:
-                merged_base = load(base_ref, strategy, abs_path)
+                merged_base = load(base_ref, strategy, abs_path, catalog_file)
             else:
-                merged_base = strategy.merge(merged_base, load(base_ref, strategy, abs_path))
+                merged_base = strategy.merge(merged_base, load(base_ref, strategy, abs_path, catalog_file))
 
     if merged_base is not None:
         schema = strategy.merge(merged_base, schema)

--- a/src/schema_merger.py
+++ b/src/schema_merger.py
@@ -1,0 +1,48 @@
+from deepmerge import Merger, always_merger
+from abc import ABC, abstractmethod, ABCMeta
+
+
+class BaseSchemaMergeStrategy(ABC):
+
+    @abstractmethod
+    def merge(self, base_schema, extension_schema):
+        pass
+
+
+class ExtensionStrategy(BaseSchemaMergeStrategy):
+    """
+    Extension schema can add new properties but cannot override base schema.
+    In case of a conflict, base schema declarations will be used.
+    """
+
+    def unique_append(config, path, base, nxt):
+        """ a list strategy to append only unique elements. """
+        if len(nxt) > 0:
+            if isinstance(nxt[0], str):
+                base.extend(x for x in nxt if x not in base)
+            else:
+                base.extend(nxt)
+        return base
+
+    my_merger = Merger(
+        [
+            (list, [unique_append, "append"]),
+            (dict, ["merge"]),
+            (set, ["union"])
+        ],
+        ["use_existing"],
+        ["use_existing"]
+    )
+
+    def merge(self, base_schema, extension_schema):
+        return self.my_merger.merge(base_schema, extension_schema)
+
+
+class OverrideStrategy(BaseSchemaMergeStrategy):
+    """
+    Extension schema can both add new properties and override base schema properties.
+    In case of a conflict, extension schema declarations will override the base schema.
+    """
+
+    def merge(self, base_schema, extension_schema):
+        return always_merger.merge(base_schema, extension_schema)

--- a/src/schema_merger.py
+++ b/src/schema_merger.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod, ABCMeta
 
 
 class BaseSchemaMergeStrategy(ABC):
+    """Abstract base schema merge strategy."""
 
     @abstractmethod
     def merge(self, base_schema, extension_schema):
@@ -11,8 +12,8 @@ class BaseSchemaMergeStrategy(ABC):
 
 class ExtensionStrategy(BaseSchemaMergeStrategy):
     """
-    Extension schema can add new properties but cannot override base schema.
-    In case of a conflict, base schema declarations will be used.
+    Extension schema can add new properties but cannot override the base schema.
+    In case of a conflict, base schema declarations will be used. Required property declarations will be merged.
     """
 
     def unique_append(config, path, base, nxt):
@@ -42,7 +43,17 @@ class OverrideStrategy(BaseSchemaMergeStrategy):
     """
     Extension schema can both add new properties and override base schema properties.
     In case of a conflict, extension schema declarations will override the base schema.
+    Required property declarations will be used from the extending schema.
     """
+    my_merger = Merger(
+        [
+            (list, ["override"]),
+            (dict, ["merge"]),
+            (set, ["override"])
+        ],
+        ["override"],
+        ["override"]
+    )
 
     def merge(self, base_schema, extension_schema):
-        return always_merger.merge(base_schema, extension_schema)
+        return self.my_merger.merge(base_schema, extension_schema)

--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -1,29 +1,15 @@
 import glob
-import json
 import sys
 import os
 from pathlib import Path
 from typing import List
+from json_utils import get_json_from_file
 import warnings
 
 from jsonschema import Draft4Validator, RefResolver, SchemaError
 
 
 warnings.filterwarnings("always")
-
-
-def get_json_from_file(filename):
-    """Loads JSON from a file."""
-    try:
-        with open(filename, "r") as f:
-            fc = f.read()
-        return json.loads(fc)
-    except FileNotFoundError:
-        warnings.warn("File not found: " + filename)
-    except IOError as exc:
-        warnings.warn("I/O error while opening " + filename + ": " + str(exc))
-    except json.JSONDecodeError as exc:
-        warnings.warn("Failed to parse JSON in " + filename + ": " + str(exc))
 
 
 def get_validator(filename, base_uri=""):

--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 from typing import List
 from json_utils import get_json_from_file
+from schema_manager import load
 import warnings
 
 from jsonschema import Draft4Validator, RefResolver, SchemaError
@@ -21,7 +22,7 @@ def get_validator(filename, base_uri=""):
     for local resolution via base_uri of form file://{some_path}/)
     """
 
-    schema = get_json_from_file(filename)
+    schema = load(filename, catalog_file="./catalog.yaml")
     try:
         # Check schema via class method call. Works, despite IDE complaining
         # However, it appears that this doesn't catch every schema issue.
@@ -98,4 +99,7 @@ def run_validator(path_to_schema_dir, schema_file, path_to_test_dir):
 if __name__ == "__main__":
     run_validator(
         path_to_schema_dir="../", schema_file="general_schema.json", path_to_test_dir="../examples/"
+    )
+    run_validator(
+        path_to_schema_dir="../", schema_file="BICAN_extension.json", path_to_test_dir="../examples/BICAN_schema_specific_examples/"
     )

--- a/src/schema_validator.py
+++ b/src/schema_validator.py
@@ -21,8 +21,8 @@ def get_validator(filename, base_uri=""):
     resolution of JSON pointers (This is especially useful
     for local resolution via base_uri of form file://{some_path}/)
     """
-
-    schema = load(filename, catalog_file="./catalog.yaml")
+    catalog_file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./catalog.yaml")
+    schema = load(filename, catalog_file=catalog_file_path)
     try:
         # Check schema via class method call. Works, despite IDE complaining
         # However, it appears that this doesn't catch every schema issue.

--- a/src/test/schema_manager_test.py
+++ b/src/test/schema_manager_test.py
@@ -1,0 +1,128 @@
+import unittest
+import os
+import json
+
+from schema_manager import load
+from schema_merger import OverrideStrategy, ExtensionStrategy
+
+GENERAL_SCHEMA = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../general_schema.json")
+BICAN_SCHEMA = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../BICAN_extension.json")
+
+
+class SchemaManagerTests(unittest.TestCase):
+
+    def test_loading_general_schema(self):
+        schema = load(GENERAL_SCHEMA)
+        print(json.dumps(schema, indent=2))
+
+        self.assertIn("title", schema)
+        self.assertEqual("General Cell Annotation Open Standard", schema["title"])
+
+        self.assertIn("Annotation", schema["definitions"])
+        self.assertIn("cellannotation_setname", schema["definitions"]["Annotation"]["properties"])
+
+        self.assertNotIn("cell_set_accession", schema["definitions"]["Annotation"]["properties"])
+        self.assertNotIn("parent_cell_set_accessions", schema["definitions"]["Annotation"]["properties"])
+
+    def test_loading_BICAN_schema(self):
+        schema = load(BICAN_SCHEMA)
+        print(json.dumps(schema, indent=2))
+
+        self.assertIn("title", schema)
+        self.assertEqual("General Cell Annotation Open Standard", schema["title"])
+
+        # from base
+        self.assertIn("automated_annotation", schema["definitions"])
+        # from bican
+        self.assertIn("Annotation_transfer", schema["definitions"])
+
+        # merged Annotation
+        self.assertIn("Annotation", schema["definitions"])
+        self.assertIn("cellannotation_setname", schema["definitions"]["Annotation"]["properties"])
+        self.assertIn("cell_set_accession", schema["definitions"]["Annotation"]["properties"])
+        self.assertIn("parent_cell_set_accessions", schema["definitions"]["Annotation"]["properties"])
+
+        # merged cellannotation_setname_metadata
+        self.assertIn("cellannotation_setname_metadata", schema["definitions"])
+        self.assertIn("rank", schema["definitions"]["cellannotation_setname_metadata"]["properties"])
+        self.assertIn("name", schema["definitions"]["cellannotation_setname_metadata"]["properties"])
+
+        self.assertNotIn("allOf", schema)
+
+    def test_import_relative_path(self):
+        test_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/BICAN_extension_relative.json")
+        schema = load(test_file)
+        print(json.dumps(schema, indent=2))
+
+        self.assertIn("title", schema)
+        self.assertEqual("General Cell Annotation Open Standard", schema["title"])
+
+        # from base
+        self.assertIn("automated_annotation", schema["definitions"])
+        # from bican
+        self.assertIn("Annotation_transfer", schema["definitions"])
+
+        # merged Annotation
+        self.assertIn("Annotation", schema["definitions"])
+        self.assertIn("cellannotation_setname", schema["definitions"]["Annotation"]["properties"])
+        self.assertIn("cell_set_accession", schema["definitions"]["Annotation"]["properties"])
+        self.assertIn("parent_cell_set_accessions", schema["definitions"]["Annotation"]["properties"])
+
+    def test_recursive_loading(self):
+        test_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/extension_2.json")
+        schema = load(test_file)
+
+        # from base_schema.json
+        self.assertIn("title", schema)
+        self.assertEqual("Person", schema["title"])
+        self.assertIn("firstName", schema["properties"])
+
+        # from extension_1.json
+        self.assertIn("occupation", schema["properties"])
+
+        # from extension_2.json
+        self.assertIn("idNumber", schema["properties"])
+
+    def test_overriding_strategy(self):
+        test_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/extension_2.json")
+        schema = load(test_file, OverrideStrategy())
+
+        # handle conflict
+        self.assertEqual("double", schema["properties"]["age"]["type"])
+        self.assertEqual("integer", schema["definitions"]["Address"]["properties"]["door_number"]["type"])
+
+        # allow property extension
+        self.assertIn("firstName", schema["properties"])
+        self.assertIn("occupation", schema["properties"])
+        self.assertIn("idNumber", schema["properties"])
+
+        # allow definition extension
+        self.assertIn("post_code", schema["definitions"]["Address"]["properties"])
+        self.assertIn("employer", schema["definitions"]["Occupation"]["properties"])
+        self.assertIn("country", schema["definitions"]["Address"]["properties"])
+
+    def test_overriding_on_required(self):
+        pass
+
+    def test_extension_strategy(self):
+        test_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/extension_2.json")
+        schema = load(test_file, ExtensionStrategy())
+
+        # handle conflict
+        self.assertEqual("integer", schema["properties"]["age"]["type"])
+        self.assertEqual("string", schema["definitions"]["Address"]["properties"]["door_number"]["type"])
+
+        # allow property extension
+        self.assertIn("firstName", schema["properties"])
+        self.assertIn("occupation", schema["properties"])
+        self.assertIn("idNumber", schema["properties"])
+
+        # allow definition extension
+        self.assertIn("post_code", schema["definitions"]["Address"]["properties"])
+        self.assertIn("employer", schema["definitions"]["Occupation"]["properties"])
+        self.assertIn("country", schema["definitions"]["Address"]["properties"])
+
+
+def test_extension_on_required(self):
+        pass
+

--- a/src/test/schema_manager_test.py
+++ b/src/test/schema_manager_test.py
@@ -7,6 +7,7 @@ from schema_merger import OverrideStrategy, ExtensionStrategy
 
 GENERAL_SCHEMA = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../general_schema.json")
 BICAN_SCHEMA = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../BICAN_extension.json")
+CAP_SCHEMA = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../CAP_extension.json")
 
 
 class SchemaManagerTests(unittest.TestCase):
@@ -49,6 +50,28 @@ class SchemaManagerTests(unittest.TestCase):
 
         self.assertNotIn("allOf", schema)
 
+    def test_loading_CAP_schema_via_expand(self):
+        schema = load(CAP_SCHEMA, ExtensionStrategy())
+        print(json.dumps(schema, indent=2))
+
+        self.assertEqual(6, len(schema["required"]))
+        self.assertIn("author_name", schema["required"])
+        self.assertIn("labelset", schema["required"])
+        self.assertIn("cellannotation_schema_version", schema["required"])
+        self.assertIn("cellannotation_timestamp", schema["required"])
+        self.assertIn("cellannotation_version", schema["required"])
+        self.assertIn("cellannotation_url", schema["required"])
+
+    def test_loading_CAP_schema_via_override(self):
+        schema = load(CAP_SCHEMA, OverrideStrategy())
+        print(json.dumps(schema, indent=2))
+
+        self.assertEqual(4, len(schema["required"]))
+        self.assertIn("cellannotation_schema_version", schema["required"])
+        self.assertIn("cellannotation_timestamp", schema["required"])
+        self.assertIn("cellannotation_version", schema["required"])
+        self.assertIn("cellannotation_url", schema["required"])
+
     def test_import_relative_path(self):
         test_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/BICAN_extension_relative.json")
         schema = load(test_file)
@@ -67,6 +90,26 @@ class SchemaManagerTests(unittest.TestCase):
         self.assertIn("cellannotation_setname", schema["definitions"]["Annotation"]["properties"])
         self.assertIn("cell_set_accession", schema["definitions"]["Annotation"]["properties"])
         self.assertIn("parent_cell_set_accessions", schema["definitions"]["Annotation"]["properties"])
+
+    def test_import_relative_path2(self):
+        test_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/folder1/folder2/extension_in_folder2.json")
+        schema = load(test_file)
+        print(json.dumps(schema, indent=2))
+
+        self.assertIn("title", schema)
+        self.assertEqual("Person", schema["title"])
+
+        #  from base_schema.json
+        self.assertIn("firstName", schema["properties"])
+        self.assertIn("post_code", schema["definitions"]["Address"]["properties"])
+
+        # from extension_in_folder1.json
+        self.assertIn("occupation", schema["properties"])
+        self.assertIn("employer", schema["definitions"]["Occupation"]["properties"])
+
+        # from extension_in_folder1.json
+        self.assertIn("idNumber", schema["properties"])
+        self.assertIn("country", schema["definitions"]["Address"]["properties"])
 
     def test_recursive_loading(self):
         test_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/extension_2.json")
@@ -102,7 +145,17 @@ class SchemaManagerTests(unittest.TestCase):
         self.assertIn("country", schema["definitions"]["Address"]["properties"])
 
     def test_overriding_on_required(self):
-        pass
+        test_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/extension_2.json")
+        schema = load(test_file, OverrideStrategy())
+        print(json.dumps(schema, indent=2))
+
+        self.assertEqual(2, len(schema["required"]))
+        self.assertIn("firstName", schema["required"])
+        self.assertIn("idNumber", schema["required"])
+
+        self.assertEqual(2, len(schema["definitions"]["Address"]["required"]))
+        self.assertIn("post_code", schema["definitions"]["Address"]["required"])
+        self.assertIn("country", schema["definitions"]["Address"]["required"])
 
     def test_extension_strategy(self):
         test_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/extension_2.json")
@@ -122,7 +175,35 @@ class SchemaManagerTests(unittest.TestCase):
         self.assertIn("employer", schema["definitions"]["Occupation"]["properties"])
         self.assertIn("country", schema["definitions"]["Address"]["properties"])
 
+    def test_extension_on_required(self):
+        test_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/extension_2.json")
+        schema = load(test_file, ExtensionStrategy())
+        print(json.dumps(schema, indent=2))
 
-def test_extension_on_required(self):
-        pass
+        self.assertEqual(4, len(schema["required"]))
+        self.assertIn("firstName", schema["required"])
+        self.assertIn("lastName", schema["required"])
+        self.assertIn("age", schema["required"])
+        self.assertIn("idNumber", schema["required"])
 
+        self.assertEqual(3, len(schema["definitions"]["Address"]["required"]))
+        self.assertIn("post_code", schema["definitions"]["Address"]["required"])
+        self.assertIn("door_number", schema["definitions"]["Address"]["required"])
+        self.assertIn("country", schema["definitions"]["Address"]["required"])
+
+    def test_catalog_file_simple(self):
+        test_file = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                 "test_data/folder1/folder2/schema_for_catalog2.json")
+        catalog_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/catalog.yaml")
+        schema = load(test_file, catalog_file=catalog_file)
+
+        # from base_schema.json
+        self.assertIn("title", schema)
+        self.assertEqual("Person", schema["title"])
+        self.assertIn("firstName", schema["properties"])
+
+        # from extension_1.json
+        self.assertIn("occupation", schema["properties"])
+
+        # from extension_2.json
+        self.assertIn("idNumber", schema["properties"])

--- a/src/test/test_data/BICAN_extension_relative.json
+++ b/src/test/test_data/BICAN_extension_relative.json
@@ -1,7 +1,7 @@
 {
     "allOf": [
       {
-        "$ref": "https://raw.githubusercontent.com/cellannotation/cell-annotation-schema/main/general_schema.json"
+        "$ref": "./general_schema.json"
       }
     ],
 

--- a/src/test/test_data/base_schema.json
+++ b/src/test/test_data/base_schema.json
@@ -1,0 +1,49 @@
+{
+  "$id": "https://example.com/person.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Person",
+  "type": "object",
+  "definitions": {
+    "Address": {
+      "type": "object",
+      "description": "Postal address.",
+      "required": [
+        "post_code",
+        "door_number"
+      ],
+      "properties": {
+        "post_code": {
+          "type": "string",
+          "description": "Postal code."
+        },
+        "door_number": {
+          "type": "string",
+          "description": "Address door number."
+        }
+      }
+    }
+  },
+  "properties": {
+    "firstName": {
+      "type": "string",
+      "description": "The person's first name."
+    },
+    "lastName": {
+      "type": "string",
+      "description": "The person's last name."
+    },
+    "age": {
+      "description": "Age in years which must be equal to or greater than zero.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "address": {
+      "type": "object",
+      "$ref":  "#/definitions/Address"
+    }
+  },
+  "required": [
+    "firstName",
+    "lastName"
+  ]
+}

--- a/src/test/test_data/catalog.yaml
+++ b/src/test/test_data/catalog.yaml
@@ -1,0 +1,2 @@
+http://www.some.not/existing/location/base_schema.json: ./base_schema.json
+http://www.some.not/existing/location/schema_for_catalog.json: ./folder1/schema_for_catalog.json

--- a/src/test/test_data/extension_1.json
+++ b/src/test/test_data/extension_1.json
@@ -1,0 +1,32 @@
+{
+  "allOf": [
+      {
+        "$ref": "./base_schema.json"
+      }
+    ],
+  "definitions": {
+    "Occupation": {
+      "properties": {
+        "employer": {
+          "type": "string",
+          "description": "Name of the employer"
+        }
+      }
+    }
+  },
+  "properties": {
+    "age": {
+      "type": "string",
+      "description": "Age of the person."
+    },
+    "occupation": {
+      "type": "object",
+      "$ref":  "#/definitions/Occupation"
+    }
+  },
+  "required": [
+    "firstName",
+    "lastName",
+    "age"
+  ]
+}

--- a/src/test/test_data/extension_2.json
+++ b/src/test/test_data/extension_2.json
@@ -1,0 +1,42 @@
+{
+  "allOf": [
+      {
+        "$ref": "./extension_1.json"
+      }
+    ],
+  "definitions": {
+    "Address": {
+      "type": "object",
+      "description": "Postal address.",
+      "required": [
+        "post_code",
+        "country"
+      ],
+      "properties": {
+        "door_number": {
+          "type": "integer",
+          "description": "Address door number."
+        },
+        "country": {
+          "type": "string",
+          "description": "Country"
+        }
+      }
+    }
+  },
+  "properties": {
+    "age": {
+      "type": "double",
+      "description": "Age of the person.",
+      "minimum": 0
+    },
+    "idNumber": {
+      "type": "string",
+      "description": "Person ID."
+    }
+  },
+  "required": [
+    "firstName",
+    "idNumber"
+  ]
+}

--- a/src/test/test_data/folder1/extension_in_folder1.json
+++ b/src/test/test_data/folder1/extension_in_folder1.json
@@ -1,0 +1,32 @@
+{
+  "allOf": [
+      {
+        "$ref": "../base_schema.json"
+      }
+    ],
+  "definitions": {
+    "Occupation": {
+      "properties": {
+        "employer": {
+          "type": "string",
+          "description": "Name of the employer"
+        }
+      }
+    }
+  },
+  "properties": {
+    "age": {
+      "type": "string",
+      "description": "Age of the person."
+    },
+    "occupation": {
+      "type": "object",
+      "$ref":  "#/definitions/Occupation"
+    }
+  },
+  "required": [
+    "firstName",
+    "lastName",
+    "age"
+  ]
+}

--- a/src/test/test_data/folder1/folder2/extension_in_folder2.json
+++ b/src/test/test_data/folder1/folder2/extension_in_folder2.json
@@ -1,0 +1,42 @@
+{
+  "allOf": [
+      {
+        "$ref": "../extension_in_folder1.json"
+      }
+    ],
+  "definitions": {
+    "Address": {
+      "type": "object",
+      "description": "Postal address.",
+      "required": [
+        "post_code",
+        "country"
+      ],
+      "properties": {
+        "door_number": {
+          "type": "integer",
+          "description": "Address door number."
+        },
+        "country": {
+          "type": "string",
+          "description": "Country"
+        }
+      }
+    }
+  },
+  "properties": {
+    "age": {
+      "type": "double",
+      "description": "Age of the person.",
+      "minimum": 0
+    },
+    "idNumber": {
+      "type": "string",
+      "description": "Person ID."
+    }
+  },
+  "required": [
+    "firstName",
+    "idNumber"
+  ]
+}

--- a/src/test/test_data/folder1/folder2/schema_for_catalog2.json
+++ b/src/test/test_data/folder1/folder2/schema_for_catalog2.json
@@ -1,0 +1,42 @@
+{
+  "allOf": [
+      {
+        "$ref": "http://www.some.not/existing/location/schema_for_catalog.json"
+      }
+    ],
+  "definitions": {
+    "Address": {
+      "type": "object",
+      "description": "Postal address.",
+      "required": [
+        "post_code",
+        "country"
+      ],
+      "properties": {
+        "door_number": {
+          "type": "integer",
+          "description": "Address door number."
+        },
+        "country": {
+          "type": "string",
+          "description": "Country"
+        }
+      }
+    }
+  },
+  "properties": {
+    "age": {
+      "type": "double",
+      "description": "Age of the person.",
+      "minimum": 0
+    },
+    "idNumber": {
+      "type": "string",
+      "description": "Person ID."
+    }
+  },
+  "required": [
+    "firstName",
+    "idNumber"
+  ]
+}

--- a/src/test/test_data/folder1/schema_for_catalog.json
+++ b/src/test/test_data/folder1/schema_for_catalog.json
@@ -1,0 +1,32 @@
+{
+  "allOf": [
+      {
+        "$ref": "http://www.some.not/existing/location/base_schema.json"
+      }
+    ],
+  "definitions": {
+    "Occupation": {
+      "properties": {
+        "employer": {
+          "type": "string",
+          "description": "Name of the employer"
+        }
+      }
+    }
+  },
+  "properties": {
+    "age": {
+      "type": "string",
+      "description": "Age of the person."
+    },
+    "occupation": {
+      "type": "object",
+      "$ref":  "#/definitions/Occupation"
+    }
+  },
+  "required": [
+    "firstName",
+    "lastName",
+    "age"
+  ]
+}

--- a/src/test/test_data/general_schema.json
+++ b/src/test/test_data/general_schema.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "General Cell Annotation Open Standard",
+  "description": "A general, open-standard schema for cell annotations which records connections, types, provenance and evidence.\nThis is designed not to tie-in to a single project (i.e. no tool-specific fields in core schema),and allows for extensions to support ad hoc user fields, new formal schema extensions, and project/tool specific metadata.",
+  "type": "object",
+  "definitions": {
+    "cellannotation_setname_metadata": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of annotation key"
+        },
+        "description": {
+          "type": "string",
+          "description": "Some text describing what types of cell annotation this annotation key is used to record"
+        }
+      }
+    },
+    "automated_annotation": {
+      "type": "object",
+      "description": "A set of fields for recording the details of the automated annotation algorithm used.\n(Common 'automated annotation methods' would include PopV, Azimuth, CellTypist, scArches, etc.)",
+      "properties": {
+        "algorithm_name": {
+              "type": "string",
+              "description": "The name of the algorithm used. It MUST be a string of the algorithm's name."
+            },
+        "algorithm_version": {
+          "type": "string",
+          "description": "The version of the algorithm used (if applicable). It MUST be a string of the algorithm's version, which is typically in the format '[MAJOR].[MINOR]', but other versioning systems are permitted (based on the algorithm's versioning)."
+            },
+        "algorithm_repo_url": {
+          "type": "string",
+          "description" : "This field denotes the URL of the version control repository associated with the algorithm used (if applicable). It MUST be a string of a valid URL."},
+        "reference_location": {
+          "type": "string",
+          "description": "This field denotes a valid URL of the reference dataset used to do annotation transfer (if applicable). This should be the URL of data portal location or other repository. \nThis MUST be a string of a valid URL. The concept of a 'reference' specifically refers to 'annotation transfer' algorithms, whereby a 'reference' dataset is used to transfer cell annotations to the 'query' dataset.",
+          "$comment": "Maybe make optional as not clear whether this always make sense"
+            }
+          },
+        "reference_cell_set_accession": "Accession/ID of cell set with transferred annotation in reference data (if applicable). This SHOULD be provided for annotation methods where this makes sense and a cell set accession exists.",
+          "required": [
+            "algorithm_name",
+            "algorithm_version",
+            "algorithm_repo_url"
+          ]
+        },
+    "Annotation": {
+      "type": "object",
+      "description": "A collection of fields recording a cell type/class/state annotation on some set os cells, supporting evidence and provenance. As this is intended as a general schema, compulsory fields are kept to a minimum. However, tools using this schema are encouarged to specify a larger set of compulsory fields for publication. \n\nNote: This schema deliberately allows for additional fields in order to support ad hoc user fields, new formal schema extensions and project/tool specific metadata.",
+      "required": [
+        "cellannotation_setname",
+        "cell_label"
+      ],
+      "properties": {
+       "cellannotation_setname": {
+          "description": "The unique name of the set of cell annotations. \nEach cell within the AnnData/Seurat file MUST be associated with a 'cell_label' value in order for this to be a valid 'cellannotation_setname'.",
+          "type": "string"
+        },
+        "cell_label": {
+          "description": "This denotes any free-text term which the author uses to annotate cells, i.e. the preferred cell label name used by the author. Abbreviations are exceptable in this field; refer to 'cell_fullname' for related details. \nCertain key words have been reserved:\n- `'doublets'` is reserved for encoding cells defined as doublets based on some computational analysis\n- `'junk'` is reserved for encoding cells that failed sequencing for some reason, e.g. few genes detected, high fraction of mitochondrial reads\n- `'unknown'` is explicitly reserved for unknown or 'author does not know'\n- `'NA'` is incomplete, i.e. no cell annotation was provided",
+          "type": "string"
+        },
+        "cell_fullname": {
+          "description": "This MUST be the full-length name for the biological entity listed in `cell_label` by the author. (If the value in `cell_label` is the full-length term, this field will contain the same value.) \nNOTE: any reserved word used in the field 'cell_label' MUST match the value of this field. \n\nEXAMPLE 1: Given the matching terms 'LC' and 'luminal cell' used to annotate the same cell(s), then users could use either terms as values in the field 'cell_label'. However, the abbreviation 'LC' CANNOT be provided in the field 'cell_fullname'. \n\nEXAMPLE 2: Either the abbreviation 'AC' or the full-length term intended by the author 'GABAergic amacrine cell' MAY be placed in the field 'cell_label', but as full-length term naming this biological entity, 'GABAergic amacrine cell' MUST be placed in the field 'cell_fullname'.",
+          "type": "string"
+        },
+        "cell_ontology_term_id": {
+          "description": "This MUST be a term from either the Cell Ontology (https://www.ebi.ac.uk/ols/ontologies/cl) or from some ontology that extends it by classifying cell types under terms from the Cell Ontology\ne.g. the Provisional Cell Ontology (https://www.ebi.ac.uk/ols/ontologies/pcl) or the Drosophila Anatomy Ontology (DAO) (https://www.ebi.ac.uk/ols4/ontologies/fbbt).\n\nNOTE: The closest available ontology term matching the value within the field 'cell_label' (at the time of publication) MUST be used.\nFor example, if the value of 'cell_label' is 'relay interneuron', but this entity does not yet exist in the ontology, users must choose the closest available term in the CL ontology. In this case, it's the broader term 'interneuron' i.e.  https://www.ebi.ac.uk/ols/ontologies/cl/terms?obo_id=CL:0000099.",
+          "type": "string"
+        },
+        "cell_ontology_term": {
+          "description": "This MUST be the human-readable name assigned to the value of 'cell_ontology_term_id'",
+          "type": "string"
+        },
+        "cell_ids": {
+          "type": "array",
+          "description": "List of cell barcode sequences/UUIDs used to uniquely identify the cells within the AnnData/Seurat matrix. Any and all cell barcode sequences/UUIDs MUST be included in the AnnData/Seurat matrix.",
+          "items": {
+            "type": "string",
+            "description": "Cell barcode sequences/UUIDs used to uniquely identify the cells within the AnnData/Seurat matrix. Any and all cell barcode sequences/UUIDs MUST be included in the AnnData/Seurat matrix."
+          }
+        },
+        "rationale": {
+          "description" : "The free-text rationale which users provide as justification/evidence for their cell annotations. \nResearchers are encouraged to use this field to cite relevant publications in-line using standard academic citations of the form `(Zheng et al., 2020)` This human-readable free-text MUST be encoded as a single string.\nAll references cited SHOULD be listed using DOIs under rationale_dois. There MUST be a 2000-character limit.",
+          "type": "string",
+          "maxLength": 2000
+        },
+        "rationale_dois": {
+          "description" : "A list of valid publication DOIs cited by the author to support or provide justification/evidence/context for 'cell_label'.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "marker_gene_evidence": {
+          "description" : "List of gene names explicitly used as evidence for this cell annotation. Each gene MUST be included in the matrix of the AnnData/Seurat file.",
+          "type": "array",
+          "items": {
+            "type": "string", 
+            "description" : "Gene names explicitly used as evidence, which MUST be in the matrix of the AnnData/Seurat file"
+          }
+        },
+        "synonyms": {
+          "description" : "This field denotes any free-text term of a biological entity which the author associates as synonymous with the biological entity listed in the field 'cell_label'.\nIn the case whereby no synonyms exist, the authors MAY leave this as blank, which is encoded as 'NA'. However, this field is NOT OPTIONAL.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "List of synonyms"
+          }
+        },
+        "provenance": {
+          "type": "object",
+          "properties": {
+            "method": {
+              "description": "This field denotes the method used for creating the cell annotations. This MUST be one of the following strings: `'algorithmic'`, `'manual'`, or `'both'` ",
+              "type": "string"
+            },
+           "automated_annotation": {
+             "type": "object",
+             "$ref":  "#/definitions/automated_annotation"}
+            }
+          }
+        }
+      }
+    },
+  "required": [
+    "author_name",
+    "labelset"
+  ],
+  "properties": {
+    "cellannotation_schema_version": {
+      "description": "The schema version, the cell annotation open standard. Current version MUST follow 0.1.0\nThis versioning MUST follow the format `'[MAJOR].[MINOR].[PATCH]'` as defined by Semantic Versioning 2.0.0, https://semver.org/",
+      "type": "string"
+    },
+    "cellannotation_timestamp": {
+      "description": "The timestamp of all cell annotations published (per dataset). This MUST be a string in the format `'%yyyy-%mm-%dd %hh:%mm:%ss'`",
+      "type": "string",
+      "format": "date-time"
+    },
+    "cellannotation_version": {
+      "description": "The version for all cell annotations published (per dataset). This MUST be a string. The recommended versioning format is `'[MAJOR].[MINOR].[PATCH]'` as defined by Semantic Versioning 2.0.0, https://semver.org/",
+      "type": "string"
+    },
+    "cellannotation_url": {
+      "description": "A persistent URL of all cell annotations published (per dataset). ",
+      "type": "string"
+    },
+    "author_name": {
+      "description": "This MUST be a string in the format `[FIRST NAME] [LAST NAME]`",
+      "type": "string"
+    },
+    "author_contact": {
+      "description": "This MUST be a valid email address of the author",
+      "type": "string",
+      "format": "email"
+    },
+    "orcid": {
+      "description": "This MUST be a valid ORCID for the author",
+      "type": "string"
+    },
+    "labelset": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Annotation"
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
In relation with Issue #13 

A new schema extension mechanism introduced. Extension schemas can now reference the base schema using the "allOf" keyword, either through an absolute URL like:
```json
"allOf": [
      {"$ref": "https://raw.githubusercontent.com/cellannotation/cell-annotation-schema/main/general_schema.json" }
    ],
```
Or, you can use relative paths for referencing the base schema:
```json
"allOf": [
      {"$ref": "./general_schema.json" }
    ],
```

We provide two conflict resolution strategies. These strategies ensure that extension schemas work seamlessly with the base schema, with the default strategy being the "ExtensionStrategy."

- **ExtensionStrategy**: In this mode, extension schema can introduce new properties without overriding the base schema. In the event of a conflict, the declarations from the base schema take precedence, and `required` property declarations are merged.
- **OverrideStrategy**: In this strategy, extension schemas have the flexibility to both add new properties and override existing properties in the base schema. When conflicts arise, the declarations from the extension schema will override those in the base schema, while `required` property declarations will be sourced from the extending schema.

To make use of these capabilities `schema_manager.load` should be used instead of `json.loads` while reading the schema files.

Moreover, catalog files introduced. While extension schemas commonly should reference base schemas via web URLs (PURLs), catalog files can be invaluable for development and testing purposes. They enable the redirection of web URLs to local schema files, facilitating a smooth development and testing workflow.