### PR TITLE
Issue 27

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -1,0 +1,45 @@
+name: Nightly Snapshot
+
+on:
+  schedule:
+  - cron: "59 23 * * *"
+  workflow_dispatch:
+
+jobs:
+  tag:
+    name: Make snapshot release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.9' ]
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Release assets generation
+        run: |
+          python src/schema_manager.py
+
+      - name: Make Snapshot
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "general_schema.json,BICAN_schema.json,CAP_schema.json"
+          body: "Nightly snapshot release. Draft only, please use a stable release instead."
+          allowUpdates: true
+          draft: true
+          makeLatest: false
+          name: "${{ steps.date.outputs.date }} SNAPSHOT"
+          removeArtifacts: true
+          tag: "snapshot"

--- a/.github/workflows/release_assets.yaml
+++ b/.github/workflows/release_assets.yaml
@@ -1,0 +1,45 @@
+name: Generate Release Assets
+
+on:
+  release:
+    types: [ created ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.9' ]
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Release assets generation
+        run: |
+          python src/schema_manager.py
+
+      - name: Upload General Schema
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: general_schema.json
+
+      - name: Upload BICAN Asset
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: BICAN_schema.json
+
+      - name: Upload CAP Asset
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: CAP_schema.json

--- a/.github/workflows/release_assets.yaml
+++ b/.github/workflows/release_assets.yaml
@@ -1,3 +1,4 @@
+# This action is used when a release is manually created from the GitHub UI
 name: Generate Release Assets
 
 on:

--- a/src/schema_manager.py
+++ b/src/schema_manager.py
@@ -1,6 +1,15 @@
+import os
+import json
+
 from schema_merger import OverrideStrategy, ExtensionStrategy
 from json_utils import get_json, resolve_path
 
+
+BICAN_SCHEMA = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../BICAN_extension.json")
+CAP_SCHEMA = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../CAP_extension.json")
+
+BICAN_ASSET = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../BICAN_schema.json")
+CAP_ASSET = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../CAP_schema.json")
 
 merge_strategy = ExtensionStrategy()
 
@@ -34,3 +43,21 @@ def load(path: str, strategy=merge_strategy, referrer_path=None, catalog_file=No
         del schema['allOf']
 
     return schema
+
+
+def generate_release_assets():
+    """
+    Generates BICAN and CAP release assets in the project root folder.
+    These assets are uploaded to the related release by GitHub actions.
+    """
+    bican_schema = load(BICAN_SCHEMA)
+    with open(BICAN_ASSET, "w") as outfile:
+        outfile.write(json.dumps(bican_schema, indent=2))
+
+    cap_schema = load(CAP_SCHEMA)
+    with open(CAP_ASSET, "w") as outfile:
+        outfile.write(json.dumps(cap_schema, indent=2))
+
+
+if __name__ == "__main__":
+    generate_release_assets()


### PR DESCRIPTION
Solves Issue #27 

_**Prerequisite**: Repo admin should give repository write permissions to workflows via `Settings`>`Actions` (left menu)>`General`> `Workflow permissions`>`Read and write permissions`_

Two GitHub actions added:

- Nightly snapshot: Runs every midnight or can be triggered manually. Builds a snapshot and adds generated schemas as assets.
- Release assets: Triggered when a release is created from GitHub user interface. Generates schemas and uploads to the created release.
