### PR TITLE
Limiting Action Status Checks to the Main Branch

### DIFF
--- a/.github/workflows/schema_validator.yaml
+++ b/.github/workflows/schema_validator.yaml
@@ -1,6 +1,8 @@
 name: JSON schema validator
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [main]
     paths:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Schema Validation](https://github.com/cellannotation/cell-annotation-schema/actions/workflows/schema_validator.yaml/badge.svg)
+![Schema Validation](https://github.com/cellannotation/cell-annotation-schema/actions/workflows/schema_validator.yaml/badge.svg?branch=main)
 # cell-annotation-schema
 
 General, open-standard schema for cell annotations


### PR DESCRIPTION
Resolves #33 

The schema validator action now triggers on main branch pushes in addition to PRs, and the status badge reflects its status on the main branch.