### PR TITLE
Spelling issue at BICAN_extension `source taxonomy`

### DIFF
--- a/BICAN_extension.json
+++ b/BICAN_extension.json
@@ -12,7 +12,7 @@
           "type": "string",
           "description": "Transferred cell label"
         },
-        "source taxonomy": {
+        "source_taxonomy": {
           "type": "string",
           "description": "PURL of source taxonomy"
         },


### PR DESCRIPTION
Space in the name replaced with underscore.