### PR TITLE
Update cap_anndata_schema.md

### DIFF
--- a/cap_anndata_schema.md
+++ b/cap_anndata_schema.md
@@ -2,8 +2,6 @@
 
 Contact: [...]
 
-Document Status: Approved
-
 Version: 0.1.0 
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED" "MAY", and "OPTIONAL" in this document are to be interpreted as described in [BCP 14](https://tools.ietf.org/html/bcp14), [RFC2119](https://www.rfc-editor.org/rfc/rfc2119.txt), and [RFC8174](https://www.rfc-editor.org/rfc/rfc8174.txt) when, and only when, they appear in all capitals, as shown here.


### PR DESCRIPTION
- Added missing sections, e.g. [cellannotation_setname]--category_fullname, [cellannotation_setname]--category_cell_ontology_exists, etc
- Added "source," "required for publication on CAP" and "example" fields
- Checked for typos and consistency 
- Changed format from bullet points to tables
- Removed character limit for descriptions
- Added 200 character limit for titles 
- Corrected .var text to indicate ENSEMBL terms are required not gene names 
