### PR TITLE
support +&- evidence markers

### DIFF
--- a/general_schema.json
+++ b/general_schema.json
@@ -106,8 +106,8 @@
             "type": "string"
           }
         },
-        "positive_marker_gene_evidence": {
-          "description": "List of names of genes whose expression is explicitly used as evidence for this cell annotation. Each gene MUST be included in the matrix of the AnnData/Seurat file.",
+        "marker_gene_evidence": {
+          "description": "List of names of genes whose expression in the cells being annotated is explicitly used as evidence for this cell annotation. Each gene MUST be included in the matrix of the AnnData/Seurat file.",
           "type": "array",
           "items": {
             "type": "string",

--- a/general_schema.json
+++ b/general_schema.json
@@ -106,8 +106,16 @@
             "type": "string"
           }
         },
-        "marker_gene_evidence": {
-          "description": "List of gene names explicitly used as evidence for this cell annotation. Each gene MUST be included in the matrix of the AnnData/Seurat file.",
+        "positive_marker_gene_evidence": {
+          "description": "List of names of genes whose expression is explicitly used as evidence for this cell annotation. Each gene MUST be included in the matrix of the AnnData/Seurat file.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Gene names explicitly used as evidence, which MUST be in the matrix of the AnnData/Seurat file"
+          }
+        },
+        "negative_marker_gene_evidence": {
+          "description": "List of names of genes, the absence of expression of which is explicitly used as evidence for this cell annotation. Each gene MUST be included in the matrix of the AnnData/Seurat file.",
           "type": "array",
           "items": {
             "type": "string",


### PR DESCRIPTION
Fixes #32

@mfutey @evanbiederstedt - would be good to add this as we have examples to support for Siletti.  Can hold off until you agree on matching update to CAP AnnData spec.