### PR TITLE
python packaging bug fix

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Release assets generation
         run: |
-          python src/cas_schema/schema_manager.py
+          PYTHONPATH=./src:$PYTHONPATH python src/cas_schema/schema_manager.py
 
       - name: Make Snapshot
         uses: ncipollo/release-action@v1

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -23,7 +23,7 @@ jobs:
         pip install -r requirements.txt
     - name: Release assets generation
       run: |
-        python src/cas_schema/schema_manager.py
+        PYTHONPATH=./src:$PYTHONPATH python src/cas_schema/schema_manager.py
     - name: Package release assets
       run: |
         mkdir -p src/cas_schema/schemas

--- a/.github/workflows/publish_to_test_pypi.yaml
+++ b/.github/workflows/publish_to_test_pypi.yaml
@@ -25,7 +25,7 @@ jobs:
         pip install -r requirements.txt
     - name: Release assets generation
       run: |
-        python src/cas_schema/schema_manager.py
+        PYTHONPATH=./src:$PYTHONPATH python src/cas_schema/schema_manager.py
     - name: Package release assets
       run: |
         mkdir -p src/cas_schema/schemas

--- a/.github/workflows/release_assets.yaml
+++ b/.github/workflows/release_assets.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Release assets generation
         run: |
-          python src/cas_schema/schema_manager.py
+          PYTHONPATH=./src:$PYTHONPATH python src/cas_schema/schema_manager.py
 
       - name: Upload General Schema
         uses: shogo82148/actions-upload-release-asset@v1

--- a/.github/workflows/schema_validator.yaml
+++ b/.github/workflows/schema_validator.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Schema validation
         id: schema
         run: |
-          python src/cas_schema/schema_validator.py
+          PYTHONPATH=./src:$PYTHONPATH python src/cas_schema/schema_validator.py
 
       - name: Prepare schema validator comment
         if: ${{ github.event_name == 'pull_request' && failure() }}

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -28,4 +28,4 @@ jobs:
 
 
       - name: Run test
-        run: PYTHONPATH=./src/scripts:$PYTHONPATH python -m unittest discover -s src -p '*_test.py'
+        run: PYTHONPATH=./src:$PYTHONPATH python -m unittest discover -s src -p '*_test.py'


### PR DESCRIPTION
After python packaging related folder structure update, GitHub actions are failing due to path errors:

```
Run python src/cas_schema/schema_validator.py
Traceback (most recent call last):
  File "/home/runner/work/cell-annotation-schema/cell-annotation-schema/src/cas_schema/schema_validator.py", line 9, in <module>
    from cas_schema.json_utils import get_json_from_file
ModuleNotFoundError: No module named 'cas_schema'
```

This bug fix guides scripts to search modules under src folder