### PR TITLE
Schema documentation auto-generate

### DIFF
--- a/.github/workflows/pr_comment_schema_roller.yaml
+++ b/.github/workflows/pr_comment_schema_roller.yaml
@@ -1,0 +1,118 @@
+# Triggered after the schema_roller.yaml
+# Comments the schema files uploaded artifact link and schema documentation files to the related PR.
+# This action is a separate action from schema_roller.yaml, because uploaded artifact ids (and the link) becomes available once the schema_roller.yaml action completed.
+name: Comment Artifact URL on PR
+
+on:
+  workflow_run:
+    types:
+      - "completed"
+    workflows:
+      - "Schema Roller"
+
+jobs:
+  comment-on-pr:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Get Artifact URL & PR Info
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          WORKFLOW_RUN_EVENT_OBJ: ${{ toJSON(github.event.workflow_run) }}
+        run: |
+          
+          PREVIOUS_JOB_ID=$(jq -r '.id' <<< "$WORKFLOW_RUN_EVENT_OBJ")
+          echo "Previous Job ID: $PREVIOUS_JOB_ID"
+          echo "PREVIOUS_JOB_ID=$PREVIOUS_JOB_ID" >> "$GITHUB_ENV"
+          
+          ARTIFACT_URL=$(gh api "/repos/$OWNER/$REPO/actions/artifacts" \
+            --jq ".artifacts.[] |
+            select(.workflow_run.id==${PREVIOUS_JOB_ID}) |
+            select(.expired==false) |
+            .archive_download_url")
+          
+          echo "ARTIFACT URL: $ARTIFACT_URL"
+          ARTIFACT_URLS="$(echo "$ARTIFACT_URL" | tr '\n' '@')"
+          ARTIFACT_URL_1="$(echo "$ARTIFACT_URLS" | cut -d'@' -f1)"
+          ARTIFACT_1_ID="$(echo "$ARTIFACT_URL_1" | cut -d'/' -f9)"
+          ARTIFACT_URL_2="$(echo "$ARTIFACT_URLS" | cut -d'@' -f2)"
+          ARTIFACT_2_ID="$(echo "$ARTIFACT_URL_2" | cut -d'/' -f9)"
+          
+          echo "ARTIFACT URL 1: $ARTIFACT_URL_1"
+          echo "ARTIFACT_1_ID=$ARTIFACT_1_ID" >> "$GITHUB_ENV"
+          echo "ARTIFACT URL 2: $ARTIFACT_URL_2"
+          echo "ARTIFACT_2_ID=$ARTIFACT_2_ID" >> "$GITHUB_ENV"
+          
+          HEAD_SHA=$(jq -r '.pull_requests[0].head.sha' \
+            <<< "$WORKFLOW_RUN_EVENT_OBJ")
+          
+          echo "Head sha: $HEAD_SHA"
+          echo "HEAD_SHA=$HEAD_SHA" >> "$GITHUB_ENV"
+
+      - name: Download workflow artifact
+        uses: dawidd6/action-download-artifact@v2.11.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: schema_roller.yaml
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Set pr_num variable
+        run: |
+          PR_NUM=$(cat pr_num/pr_num.txt)
+          echo "PR_NUM: $PR_NUM"
+          echo "PR_NUM=$PR_NUM" >> "$GITHUB_ENV"
+
+      - name: Set head_ref variable
+        run: |
+          HEAD_REF=$(cat head_ref/head_ref.txt)
+          echo "HEAD_REF: $HEAD_REF"
+          echo "HEAD_REF=$HEAD_REF" >> "$GITHUB_ENV"
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.HEAD_REF }}
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        if: steps.check.outputs.triggered == 'true'
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        if: steps.check.outputs.triggered == 'true'
+        run: pip install -r requirements.txt
+
+      - name: Release assets generation
+        if: steps.check.outputs.triggered == 'true'
+        run: |
+          PYTHONPATH=./src:$PYTHONPATH python src/cas_schema/schema_manager.py
+
+      - name: Schema documentation generation
+        if: steps.check.outputs.triggered == 'true'
+        run: |
+          PYTHONPATH=./src:$PYTHONPATH python src/cas_schema/schema_docs.py
+
+      - name: Prepare download links comment
+        run: "echo \"Rolled schema files: [schemas.zip](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ env.PREVIOUS_JOB_ID }}/artifacts/${{ env.ARTIFACT_1_ID }})\" >schema-comment.md"
+
+      - name: Prepare BICAN schema doc comment
+        run: "echo \"\n<details>\n <summary> BICAN schema documentation</summary> \n\" >> schema-comment.md; cat BICAN_schema.md >>schema-comment.md"
+
+      - name: Prepare CAP schema doc comment
+        run: "echo \"\n</details>\n\n<details>\n <summary> CAP schema documentation</summary> \n\" >> schema-comment.md; cat CAP_schema.md >>schema-comment.md"
+
+      - name: Schema Docs Comment
+        env:
+          JOB_PATH: "${{ github.server_url }}/${{ github.repository }}/actions/\
+              runs/${{ env.PREVIOUS_JOB_ID }}"
+          HEAD_SHA: ${{ env.HEAD_SHA }}
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ env.PR_NUM }}
+          body-path: schema-comment.md

--- a/.github/workflows/schema_roller.yaml
+++ b/.github/workflows/schema_roller.yaml
@@ -1,0 +1,88 @@
+# Listens for '#rollschema' keyword in the pull request comments. If keyword is triggered, generates and uploads merged schemas.
+# This action is followed by pr_comment_schema_roller.yaml that comments about the uploaded artifact.
+name: 'Schema Roller'
+
+on:
+  issue_comment:
+    types: [created]
+
+env:
+  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+
+jobs:
+  roll_schema:
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.9' ]
+    steps:
+      - uses: khan/pull-request-comment-trigger@v1.1.0
+        id: check
+        with:
+          trigger: '#rollschema'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+      - uses: xt0rted/pull-request-comment-branch@v1
+        id: comment-branch
+
+      - name: Checkout Repository
+        if: steps.check.outputs.triggered == 'true'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        if: steps.check.outputs.triggered == 'true'
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        if: steps.check.outputs.triggered == 'true'
+        run: pip install -r requirements.txt
+
+      - name: Release assets generation
+        if: steps.check.outputs.triggered == 'true'
+        run: |
+          PYTHONPATH=./src:$PYTHONPATH python src/cas_schema/schema_manager.py
+
+      - name: Upload artefacts
+        if: steps.check.outputs.triggered == 'true'
+        uses: actions/upload-artifact@v2
+        with:
+          name: schemas
+          path: |
+            BICAN_schema.json
+            CAP_schema.json
+
+      - name: Save the PR number in an artifact
+        shell: bash
+        run: |
+          PR_URL="${{ github.event.issue.pull_request.url }}"
+          PR_NUM=${PR_URL##*/}
+          echo "PR_NUM: $PR_NUM"
+          echo $PR_NUM > pr_num.txt
+
+      # To share PR number with the consecutive action (pr_comment_schema_roller.yaml)
+      - name: Upload the PR number
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr_num
+          path: ./pr_num.txt
+
+      - name: Save the Head Ref in an artifact
+        shell: bash
+        run: |
+          HEAD_REF="${{ steps.comment-branch.outputs.head_ref }}"
+          echo "HEAD_REF: $HEAD_REF"
+          echo $HEAD_REF > head_ref.txt
+
+      # To share head ref with the consecutive action (pr_comment_schema_roller.yaml)
+      - name: Upload the Head Ref
+        uses: actions/upload-artifact@v2
+        with:
+          name: head_ref
+          path: ./head_ref.txt

--- a/general_schema.json
+++ b/general_schema.json
@@ -167,7 +167,9 @@
     },
     "labelsets": {
       "type": "array",
-      "$ref": "#/definitions/Labelset"
+      "items": {
+        "$ref": "#/definitions/Labelset"
+      }
     },
     "annotations": {
       "type": "array",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ jsonschema==4.4.0
 ordered-set==4.1.0
 deepmerge==1.1.0
 ruamel.yaml
+jsonschema2md

--- a/src/cas_schema/schema_docs.py
+++ b/src/cas_schema/schema_docs.py
@@ -1,0 +1,347 @@
+import os
+import logging
+import jsonschema2md
+
+from cas_schema.json_utils import get_json_from_file
+
+
+NESTED_REFERENCE_LIMIT = 3
+
+DEFINITION_PREFIX = "def_"
+
+CROSS_REF_TERM = "Refer to *[#/definitions/"
+CROSS_REF_TERM_ALT = "Values from *"
+
+logging.basicConfig(level=logging.INFO)
+
+BICAN_SCHEMA = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../BICAN_schema.json")
+CAP_SCHEMA = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../CAP_schema.json")
+
+
+def generate_plain_documentation(schema_path, mapping_definitions):
+    """
+    Generates a plain documentation using jsonschema2md library.
+
+    Returns: Dictionary of element documentations. Key is element name and value is list of documentation lines.
+    """
+    parser = jsonschema2md.Parser()
+
+    schema = get_json_from_file(schema_path)
+    md_lines = parser.parse_schema(schema)
+    # with open('out.md', 'w') as f:
+    #     f.writelines(md_lines)
+
+    plain_documentation = dict()
+    element_lines = []
+    element_name = ""
+
+    is_definition = False
+    element_path = list()
+    prev_indent = 0
+    curr_indent = 0
+    for line in md_lines:
+        if line.startswith("## Definitions"):
+            is_definition = True
+        elif line.startswith("## Properties"):
+            is_definition = False
+
+        line = line.replace("\n", "")
+
+        if line.startswith("- **`") or line.startswith("- <a id=\"definitions/"):
+            if element_name:
+                plain_documentation[element_name] = element_lines
+            element_name = get_element_name(is_definition, line)
+            element_path = [element_name]
+            line = insert_mapping_definition(element_path, line, mapping_definitions)
+            element_lines = [line]
+            curr_indent = 0
+        elif line and not line.startswith("#"):
+            prev_indent = curr_indent
+            curr_indent = len(line) - len(line.lstrip(' '))
+
+            if element_path:
+                if curr_indent == prev_indent:
+                    element_path.remove(element_path[-1])
+                elif curr_indent <= prev_indent:
+                    element_path.remove(element_path[-1])
+                    element_path.remove(element_path[-1])
+                element_path.append(get_element_name(False, line))
+
+            line = insert_mapping_definition(element_path, line, mapping_definitions)
+            element_lines.append(line)
+
+    plain_documentation[element_name] = element_lines
+    handle_one_of_definitions(schema, plain_documentation)
+
+    return plain_documentation
+
+
+def insert_mapping_definition(element_path, line, mapping_definitions):
+    """
+    Inserts mapping definition to the element description if required. Otherwise, returns the line as is.
+    """
+    if "$".join(element_path).replace("def_", "").lower() in mapping_definitions:
+        if "*:" in line:
+            parts = line.split("*:")
+            line = (parts[0] + "*:" + " Mapped to `" +
+                    mapping_definitions["$".join(element_path).replace("def_", "").lower()] + "`. " + parts[1])
+    return line
+
+
+def get_element_name(is_definition, line):
+    """
+    Extract element name from jsonschema2md generated documentation line.
+    """
+    first_occur = line.index("**")
+    second_occur = line.index("**", first_occur + 1)
+    element_name = line[first_occur + 2:second_occur]
+    if "`" in element_name:
+        element_name = element_name.replace("`", "").strip()
+    if is_definition:
+        element_name = DEFINITION_PREFIX + element_name
+
+    return element_name
+
+
+def find_mapping_definitions(schema):
+    """
+    'Mapping' definitions are not handled by the jsonschema2md. To manually add documentation for these definitions,
+    searches for all mapping definitions in the schema.
+
+    Return: Dictionary of mapping definitions. Key is path of the mapping element,
+    value is value of the mapping definition.
+    """
+    mapping_definitions = dict()
+    path = list()
+    scan_element_for_mapping(schema, mapping_definitions, path)
+
+    return mapping_definitions
+
+
+def scan_element_for_mapping(element, mapping_definitions, path):
+    """
+    Recursively scans schema to identify mapping definitions. Fills the mapping definitions dictionary.
+    """
+    for key in element.keys():
+        path.append(key)
+        if "mapping" == key:
+            path_refine = path[0:len(path) - 1]
+            if "definitions" in path_refine: path_refine.remove("definitions")
+            if "properties" in path_refine: path_refine.remove("properties")
+            mapping_definitions["$".join(path_refine)] = element["mapping"]
+        elif isinstance(element[key], dict):
+            scan_element_for_mapping(element[key], mapping_definitions, path)
+        path.remove(key)
+
+
+def handle_one_of_definitions(schema, plain_documentation):
+    """
+    'OneOf' definitions are not handled by the jsonschema2md. Manually adding documentation for these definitions.
+    """
+    definitions = schema["definitions"]
+    for key in definitions.keys():
+        if "oneOf" in definitions[key]:
+            one_of_defs = definitions[key]["oneOf"]
+            if "$ref" in one_of_defs[0]:
+                element_lines = ["- **`annotations`** *(array)*: One of the followings:"]
+                for one_of_item in one_of_defs:
+                    element_lines.append("  - **Items**: Refer to *" + one_of_item["$ref"] + "*.")
+                plain_documentation[DEFINITION_PREFIX + key] = element_lines
+
+
+def print_documentation_header(doc_type_elements, config, md_out):
+    """
+    Adds headings and table of contents to the documentation.
+    """
+    md_out.write("# %s\n" % doc_type_elements["doc_title"])
+    md_out.write("\n")
+
+    if "doc_description" in doc_type_elements:
+        md_out.write("*%s*\n" % doc_type_elements["doc_description"])
+        md_out.write("\n")
+
+    print_documentation_toc(config, md_out)
+
+    md_out.write("\n")
+    md_out.write("## %s\n" % "Properties")
+    md_out.write("\n")
+
+
+def print_documentation_toc(config, md_out):
+    """
+    Prints table of contents based on documentation config.
+    """
+    for section in config:
+        section_config = config[section]
+        if section == "root":
+            md_out.write("- [" + section_config["title"] + "](#" +
+                         section_config["title"].lower().replace(" ", "-") + ")\n")
+        else:
+            md_out.write("  * [" + section_config["title"] + "](#" +
+                         section_config["title"].lower().replace(" ", "-") + ")\n")
+
+
+def print_element(element, md_out, plain_doc, prefix="", nesting_list=[], in_reference=False):
+    """
+    Retrieves plain element documentation generated by the jsonschema2md and writes to the document.
+    Additionally, expands 'definitions' references to a specified depth (see NESTED_REFERENCE_LIMIT)
+    in order to prevent indefinite circular references.
+    """
+    # prefix = ">" * (len(nesting_list))
+    indentation = prefix + ("  " * (len(nesting_list) % 2))
+    lines = plain_doc[element]
+
+    # postpone writing references (as last items) to make it more readable
+    reference_defs = list()
+    reference_elements = dict()
+    is_annotation = False
+    for count, line in enumerate(lines):
+        line = customize_doc_content(line)
+
+        if "**`annotations`** *(array)*" in line:
+            reference_definition = indentation + line
+            reference_defs.append(reference_definition)
+            reference_elements[reference_definition] = list()
+            is_annotation = True
+        elif CROSS_REF_TERM_ALT in line:
+            nesting_list.append(element)
+            ref_term_start = line.index(CROSS_REF_TERM_ALT) + len(CROSS_REF_TERM_ALT)
+            referred_element = line[ref_term_start:len(line) - 2]
+            if "]" in referred_element:
+                referred_element = referred_element.split("]")[0]
+
+            if is_annotation:
+                reference_elements[reference_defs[-1]].append(DEFINITION_PREFIX + referred_element)
+            else:
+                if "- **Items**" not in line:
+                    md_out.write("%s\n" % (indentation + line.split(CROSS_REF_TERM_ALT)[0].rstrip()))
+                    # md_out.write("%s\n" % (indentation + line))
+                if (DEFINITION_PREFIX + referred_element) not in nesting_list:
+                    print_element(DEFINITION_PREFIX + referred_element, md_out, plain_doc,
+                                  "" if len(nesting_list) == 1 else indentation + "  ", nesting_list)
+                else:
+                    # ellipsis to indicate recursion
+                    md_out.write("%s\n" % (indentation + " " * (len(line) - len(line.lstrip())) + "  - ..."))
+        else:
+            is_annotation = False
+            if not (element.startswith(DEFINITION_PREFIX) and count == 0 and not in_reference) \
+                    and "- **Items**" not in line and "_annotation`** *(object)*:" not in line:
+                md_out.write("%s\n" % (indentation + line))
+
+    for count, reference in enumerate(reference_defs):
+        if "**`annotations`** *(list)*: One of the followings:" in reference:
+            md_out.write("%s\n" % (indentation + "*Use one of the followings:*"))
+        else:
+            md_out.write("%s\n" % reference)
+        for element in reference_elements[reference]:
+            if element not in nesting_list:
+                md_out.write("\n")
+                print_element(element, md_out, plain_doc,
+                              prefix if prefix.startswith(">") else ">" + prefix, nesting_list, in_reference=True)
+            else:
+                # ellipsis to indicate recursion
+                line_content = reference.replace(">", "")
+                md_out.write("%s\n" % (indentation + " " * (len(line_content) - len(line_content.lstrip())) + "  - ..."))
+
+
+def customize_doc_content(line):
+    """
+    Place content customizations to here. Such as don't display "array", use "list instead"
+    """
+    if "*(array)*" in line:
+        line = line.replace("*(array)*", "*(list)*")
+
+    if "*(array)*" in line:
+        line = line.replace("*(object)*", "*(dict)*")
+
+    if CROSS_REF_TERM in line:
+        line = line.replace(CROSS_REF_TERM, CROSS_REF_TERM_ALT)
+
+    return line
+
+
+def print_section_header(config, md_out, section):
+    """
+    Adds a section title and description for doc_type.
+    'root' doc_type is a special type and doesn't have a title and description.
+    """
+    if not section == "root":
+        section_config = config[section]
+        md_out.write("### %s\n" % section_config["title"])
+        md_out.write("\n")
+        md_out.write("%s\n" % section_config["description"])
+        md_out.write("\n")
+
+
+def get_doc_type_elements(schema):
+    """
+    Reads the schema file and builds a list of doc_type elements.
+
+    Returns: dictionary of schema elements. Key is doc_type (as defined in the ini config)
+    and value is list of element names.
+    """
+    doc_type_elements = dict()
+
+    doc_type_elements["doc_title"] = schema["title"]
+    if "description" in schema:
+        doc_type_elements["doc_description"] = schema["description"]
+
+    properties = schema["properties"]
+
+    for key in properties.keys():
+        if "doc_type" in properties[key]:
+            doc_type = properties[key]["doc_type"]
+        else:
+            doc_type = "root"
+
+        if doc_type in doc_type_elements:
+            doc_type_elements[doc_type].append(key)
+        else:
+            doc_type_elements[doc_type] = [key]
+
+    return doc_type_elements
+
+
+def generate_schema_documentation(schema_path, md_output=None):
+    """
+    Generates documentation for the given YAML schema. Uses jsonschema2md to generate a plain documentation,
+    then decorates generated documentation through using the documentation config (.ini file)
+    """
+    if not md_output:
+        pre, ext = os.path.splitext(schema_path)
+        md_output = pre + ".md"
+
+    schema = get_json_from_file(schema_path)
+
+    mapping_definitions = find_mapping_definitions(schema)
+    plain_doc = generate_plain_documentation(schema_path, mapping_definitions)
+
+    # config = configparser.ConfigParser()
+    # config.read(DOSDP_DOCUMENTATION_CONF)
+    # sections = config.sections()
+    config = {"root": {"title": "Properties", "description": ""}}
+    sections = config.keys()
+
+    doc_type_elements = get_doc_type_elements(schema)
+
+    # if os.path.isdir(md_output):
+    #     file_name = os.path.basename(yaml_schema)
+    #     md_output = os.path.join(md_output, (os.path.splitext(file_name)[0] + ".md"))
+
+    logging.info("Target is: " + os.path.abspath(md_output))
+    with open(md_output, "w") as md_out:
+        print_documentation_header(doc_type_elements, config, md_out)
+
+        for section in sections:
+            elements = doc_type_elements[section]
+            print_section_header(config, md_out, section)
+
+            for element in elements:
+                print_element(element, md_out, plain_doc, nesting_list=[])
+                md_out.write("\n\n")
+
+
+if __name__ == "__main__":
+    generate_schema_documentation(BICAN_SCHEMA)
+    generate_schema_documentation(CAP_SCHEMA)
+


### PR DESCRIPTION
Related with #48 

This PR adds schema documentation auto-generation capabilities. A sample auto-generated documentation is as follows:

<details>
<summary> BICAN schema documentation</summary>

# General Cell Annotation Open Standard

*A general, open-standard schema for cell annotations which records connections, types, provenance and evidence.
This is designed not to tie-in to a single project (i.e. no tool-specific fields in core schema),and allows for extensions to support ad hoc user fields, new formal schema extensions, and project/tool specific metadata.*

- [Properties](#properties)

## Properties

- **`matrix_file_id`** *(string)*: A resolvable ID for a cell by gene matrix file in the form namespace:accession, e.g. CellXGene_dataset:8e10f1c4-8e98-41e5-b65f-8cd89a887122.  Please see https://github.com/cellannotation/cell-annotation-schema/registry/registry.json for supported namespaces.


- **`cellannotation_schema_version`** *(string)*: The schema version, the cell annotation open standard. Current version MUST follow 0.1.0This versioning MUST follow the format `'[MAJOR].[MINOR].[PATCH]'` as defined by Semantic Versioning 2.0.0, https://semver.org/.


- **`cellannotation_timestamp`** *(string, format: date-time)*: The timestamp of all cell annotations published (per dataset). This MUST be a string in the format `'%yyyy-%mm-%dd %hh:%mm:%ss'`.


- **`cellannotation_version`** *(string)*: The version for all cell annotations published (per dataset). This MUST be a string. The recommended versioning format is `'[MAJOR].[MINOR].[PATCH]'` as defined by Semantic Versioning 2.0.0, https://semver.org/.


- **`cellannotation_url`** *(string)*: A persistent URL of all cell annotations published (per dataset). .


- **`author_name`** *(string)*: This MUST be a string in the format `[FIRST NAME] [LAST NAME]`.


- **`author_contact`** *(string, format: email)*: This MUST be a valid email address of the author.


- **`orcid`** *(string)*: This MUST be a valid ORCID for the author.


- **`labelsets`** *(list)*
    - **`name`** *(string, required)*: name of annotation key.
    - **`description`** *(string)*: Some text describing what types of cell annotation this annotation key is used to record.
    - **`annotation_method`** *(string)*: The method used for creating the cell annotations. This MUST be one of the following strings: `'algorithmic'`, `'manual'`, or `'both'` . Must be one of: `["algorithmic", "manual", "both"]`.
    - **`automated_annotation`** *(object)*:
      - **`algorithm_name`** *(string, required)*: The name of the algorithm used. It MUST be a string of the algorithm's name.
      - **`algorithm_version`** *(string, required)*: The version of the algorithm used (if applicable). It MUST be a string of the algorithm's version, which is typically in the format '[MAJOR].[MINOR]', but other versioning systems are permitted (based on the algorithm's versioning).
      - **`algorithm_repo_url`** *(string, required)*: This field denotes the URL of the version control repository associated with the algorithm used (if applicable). It MUST be a string of a valid URL.
      - **`reference_location`** *(string)*: This field denotes a valid URL of the annotated dataset that was the source of annotated reference data. This MUST be a string of a valid URL. The concept of a 'reference' specifically refers to 'annotation transfer' algorithms, whereby a 'reference' dataset is used to transfer cell annotations to the 'query' dataset.
    - **`rank`** *(integer)*: A number indicating relative granularity with 0 being the most specific.  Use this where a single dataset has multiple keys that are used consistently to record annotations and different levels of granularity.


- **`annotations`** *(list)*
    - **`labelset`** *(string, required)*: The unique name of the set of cell annotations. Each cell within the AnnData/Seurat file MUST be associated with a 'cell_label' value in order for this to be a valid 'cellannotation_setname'.
    - **`cell_label`** *(string, required)*: This denotes any free-text term which the author uses to annotate cells, i.e. the preferred cell label name used by the author. Abbreviations are exceptable in this field; refer to 'cell_fullname' for related details. Certain key words have been reserved:- `'doublets'` is reserved for encoding cells defined as doublets based on some computational analysis- `'junk'` is reserved for encoding cells that failed sequencing for some reason, e.g. few genes detected, high fraction of mitochondrial reads- `'unknown'` is explicitly reserved for unknown or 'author does not know'- `'NA'` is incomplete, i.e. no cell annotation was provided.
    - **`cell_fullname`** *(string)*: This MUST be the full-length name for the biological entity listed in `cell_label` by the author. (If the value in `cell_label` is the full-length term, this field will contain the same value.) NOTE: any reserved word used in the field 'cell_label' MUST match the value of this field. <br>    EXAMPLE 1: Given the matching terms 'LC' and 'luminal cell' used to annotate the same cell(s), then users could use either terms as values in the field 'cell_label'. However, the abbreviation 'LC' CANNOT be provided in the field 'cell_fullname'. <br>    EXAMPLE 2: Either the abbreviation 'AC' or the full-length term intended by the author 'GABAergic amacrine cell' MAY be placed in the field 'cell_label', but as full-length term naming this biological entity, 'GABAergic amacrine cell' MUST be placed in the field 'cell_fullname'.
    - **`cell_ontology_term_id`** *(string)*: This MUST be a term from either the Cell Ontology (https://www.ebi.ac.uk/ols/ontologies/cl) or from some ontology that extends it by classifying cell types under terms from the Cell Ontologye.g. the Provisional Cell Ontology (https://www.ebi.ac.uk/ols/ontologies/pcl) or the Drosophila Anatomy Ontology (DAO) (https://www.ebi.ac.uk/ols4/ontologies/fbbt).<br>    NOTE: The closest available ontology term matching the value within the field 'cell_label' (at the time of publication) MUST be used.For example, if the value of 'cell_label' is 'relay interneuron', but this entity does not yet exist in the ontology, users must choose the closest available term in the CL ontology. In this case, it's the broader term 'interneuron' i.e.  https://www.ebi.ac.uk/ols/ontologies/cl/terms?obo_id=CL:0000099.
    - **`cell_ontology_term`** *(string)*: This MUST be the human-readable name assigned to the value of 'cell_ontology_term_id'.
    - **`cell_ids`** *(list)*: List of cell barcode sequences/UUIDs used to uniquely identify the cells within the AnnData/Seurat matrix. Any and all cell barcode sequences/UUIDs MUST be included in the AnnData/Seurat matrix.
    - **`rationale`** *(string)*: The free-text rationale which users provide as justification/evidence for their cell annotations. Researchers are encouraged to use this field to cite relevant publications in-line using standard academic citations of the form `(Zheng et al., 2020)` This human-readable free-text MUST be encoded as a single string.All references cited SHOULD be listed using DOIs under rationale_dois. There MUST be a 2000-character limit.
    - **`rationale_dois`** *(list)*: A list of valid publication DOIs cited by the author to support or provide justification/evidence/context for 'cell_label'.
    - **`marker_gene_evidence`** *(list)*: List of gene names explicitly used as evidence for this cell annotation. Each gene MUST be included in the matrix of the AnnData/Seurat file.
    - **`synonyms`** *(list)*: This field denotes any free-text term of a biological entity which the author associates as synonymous with the biological entity listed in the field 'cell_label'.In the case whereby no synonyms exist, the authors MAY leave this as blank, which is encoded as 'NA'. However, this field is NOT OPTIONAL.
    - **`cell_set_accession`** *(string)*: An identifier that can be used to consistently refer to the set of cells being annotated, even if the cell_label changes.
    - **`parent_cell_set_accessions`** *(list)*: A list of accessions of cell sets that subsume this cell set. This can be used to compose hierarchies of annotated cell sets, built from a fixed set of clusters.
    - **`transferred_annotations`** *(list)*
      - **`transferred_cell_label`** *(string)*: Transferred cell label.
      - **`source_taxonomy`** *(string)*: PURL of source taxonomy.
      - **`source_node_accession`** *(string)*: accession of node that label was transferred from.
      - **`algorithm_name`** *(string)*: .
      - **`comment`** *(string)*: Free text comment on annotation transfer.
</details>

Additionally, `#rollschema` pull request comment trigger is introduced. When triggered generates merged schemas and their documentations, then comments the generated documentation and a link to the generated schemas zip file.
