### PR TITLE
Update field names

### DIFF
--- a/docs/cap_anndata_schema.md
+++ b/docs/cap_anndata_schema.md
@@ -1210,6 +1210,35 @@ Key-value pair in the `uns` dictionary
 	</tr>
 </tbody></table>
 
+## cap_publication_url
+
+Key-value pair in the `uns` dictionary
+
+<table><tbody>
+	<tr>
+  		<td><b>key</b></td>
+  		<td><code>cap_publication_url</code></td>
+	</tr>
+	<tr>
+  		<td><b>type</b></td>
+  		<td>string</td>
+	</tr>
+	<tr>
+  		<td><b>value</b></td>
+  		<td>A persistent URL of the publication on CAP.<br><br>NOTE: the term "publication" refers to the workspace published on CAP with a version and timestamp.</td></td>
+	</tr>
+  		<td><b>source</b></td>
+  		<td>software</td>
+	</tr>
+	<tr>
+  		<td><b>required for publication on CAP</b></td>
+  		<td>yes</td>
+	</tr>
+	<tr>
+  		<td><b>example</b></td>
+  		<td><code>'https://celltype.info/CAP_DataCuration/A-Single-Cell-Transcriptome-Atlas-of-the-Human-Pancreas/1'</code></td>
+	</tr>
+</tbody></table>
 
 ## authors_list
 
@@ -1238,36 +1267,6 @@ Key-value pair in the `uns` dictionary
 	<tr>
   		<td><b>example</b></td>
   		<td><code>'['John Smith', 'Cody Miller', 'Sarah Jones']'</code></td>
-	</tr>
-</tbody></table>
-
-## cap_publication_url
-
-Key-value pair in the `uns` dictionary
-
-<table><tbody>
-	<tr>
-  		<td><b>key</b></td>
-  		<td><code>cap_publication_url</code></td>
-	</tr>
-	<tr>
-  		<td><b>type</b></td>
-  		<td>string</td>
-	</tr>
-	<tr>
-  		<td><b>value</b></td>
-  		<td>A persistent URL of the publication on CAP.<br><br>NOTE: the term "publication" refers to the workspace published on CAP with a version and timestamp.</td></td>
-	</tr>
-  		<td><b>source</b></td>
-  		<td>software</td>
-	</tr>
-	<tr>
-  		<td><b>required for publication on CAP</b></td>
-  		<td>yes</td>
-	</tr>
-	<tr>
-  		<td><b>example</b></td>
-  		<td><code>'https://celltype.info/CAP_DataCuration/A-Single-Cell-Transcriptome-Atlas-of-the-Human-Pancreas/1'</code></td>
 	</tr>
 </tbody></table>
 

--- a/docs/cap_anndata_schema.md
+++ b/docs/cap_anndata_schema.md
@@ -1270,14 +1270,14 @@ Key-value pair in the `uns` dictionary
 	</tr>
 </tbody></table>
 
-## main_author
+## author_name
 
 Key-value pair in the `uns` dictionary
 
 <table><tbody>
 	<tr>
   		<td><b>key</b></td>
-  		<td><code>main_author</code></td>
+  		<td><code>author_name</code></td>
 	</tr>
 	<tr>
   		<td><b>type</b></td>
@@ -1302,14 +1302,14 @@ Key-value pair in the `uns` dictionary
 </tbody></table>
 
 
-## main_author_contact
+## author_contact
 
 Key-value pair in the `uns` dictionary
 
 <table><tbody>
 	<tr>
   		<td><b>key</b></td>
-  		<td><code>main_author_contact</code></td>
+  		<td><code>author_contact</code></td>
 	</tr>
 	<tr>
   		<td><b>type</b></td>
@@ -1333,14 +1333,14 @@ Key-value pair in the `uns` dictionary
 	</tr>
 </tbody></table>
 
-## main_author_orcid
+## author_orcid
 
 Key-value pair in the `uns` dictionary
 
 <table><tbody>
 	<tr>
   		<td><b>key</b></td>
-  		<td><code>main_author_orcid</code></td>
+  		<td><code>author_orcid</code></td>
 	</tr>
 	<tr>
   		<td><b>type</b></td>

--- a/docs/cap_anndata_schema.md
+++ b/docs/cap_anndata_schema.md
@@ -993,14 +993,14 @@ This versioning MUST follow the format <code>'[MAJOR].[MINOR].[PATCH]'</code> as
 </tbody></table>
 
 
-## cap_publication_timestamp
+## publication_timestamp
 
 Key-value pair in the `uns` dictionary
 
 <table><tbody>
 	<tr>
   		<td><b>key</b></td>
-  		<td><code>cap_dataset_timestamp</code></td>
+  		<td><code>publication_timestamp</code></td>
 	</tr>
 	<tr>
   		<td><b>type</b></td>
@@ -1024,14 +1024,14 @@ Key-value pair in the `uns` dictionary
 	</tr>
 </tbody></table>
 
-## cap_publication_version
+## publication_version
 
 Key-value pair in the `uns` dictionary
 
 <table><tbody>
 	<tr>
   		<td><b>key</b></td>
-  		<td><code>cap_dataset_version</code></td>
+  		<td><code>publication_version</code></td>
 	</tr>
 	<tr>
   		<td><b>type</b></td>
@@ -1211,14 +1211,14 @@ Key-value pair in the `uns` dictionary
 </tbody></table>
 
 
-## cap_publication_authors_list
+## authors_list
 
 Key-value pair in the `uns` dictionary
 
 <table><tbody>
 	<tr>
   		<td><b>key</b></td>
-  		<td><code>cap_publication_authors_list</code></td>
+  		<td><code>authors_list</code></td>
 	</tr>
 	<tr>
   		<td><b>type</b></td>
@@ -1271,14 +1271,14 @@ Key-value pair in the `uns` dictionary
 	</tr>
 </tbody></table>
 
-## cap_author_name
+## main_author
 
 Key-value pair in the `uns` dictionary
 
 <table><tbody>
 	<tr>
   		<td><b>key</b></td>
-  		<td><code>cap_author_name</code></td>
+  		<td><code>main_author</code></td>
 	</tr>
 	<tr>
   		<td><b>type</b></td>
@@ -1303,14 +1303,14 @@ Key-value pair in the `uns` dictionary
 </tbody></table>
 
 
-## cap_author_contact
+## main_author_contact
 
 Key-value pair in the `uns` dictionary
 
 <table><tbody>
 	<tr>
   		<td><b>key</b></td>
-  		<td><code>cap_author_contact</code></td>
+  		<td><code>main_author_contact</code></td>
 	</tr>
 	<tr>
   		<td><b>type</b></td>
@@ -1334,14 +1334,14 @@ Key-value pair in the `uns` dictionary
 	</tr>
 </tbody></table>
 
-## cap_author_orcid
+## main_author_orcid
 
 Key-value pair in the `uns` dictionary
 
 <table><tbody>
 	<tr>
   		<td><b>key</b></td>
-  		<td><code>cap_author_orcid</code></td>
+  		<td><code>main_author_orcid</code></td>
 	</tr>
 	<tr>
   		<td><b>type</b></td>


### PR DESCRIPTION
For [MVP-4961](https://capdevelopment.atlassian.net/browse/MVP-4961): 

1. Updated the following field names: 

    "cap_publication_authors_list" -> "authors_list"
    "cap_publication_timestamp" -> "publication_timestamp"
    "cap_publication_version" -> "publication_version"
    "cap_author_name" -> "main_author"
    "cap_author_orcid" -> "main_author_orcid"
    "cap_author_contact" -> "main_author_contact"

2. Changed the order of the fields so that the "cap_" fields are grouped together. The only .uns fields with "cap_" prefix are:

    "cap_publication_title"
    "cap_publication_description"
    "cap_publication_url"

