### PR TITLE
cannonical_marker_genes

### DIFF
--- a/CAP_extension.json
+++ b/CAP_extension.json
@@ -6,6 +6,13 @@
     ],
 
   "definitions": {
+    "Annotation": {
+      "canonical_marker_genes": {
+        "type": "array",
+        "items": "string",
+        "description": "A list of gene names considered to be canonical markers for the biological entity used in the cell annotation."
+      }
+    }
   },
   "properties":{
     "cap_publication_title": {

--- a/CAP_extension.json
+++ b/CAP_extension.json
@@ -7,10 +7,12 @@
 
   "definitions": {
     "Annotation": {
-      "canonical_marker_genes": {
-        "type": "array",
-        "items": "string",
-        "description": "A list of gene names considered to be canonical markers for the biological entity used in the cell annotation."
+      "properties": {
+        "canonical_marker_genes": {
+          "type": "array",
+          "items": "string",
+          "description": "A list of gene names considered to be canonical markers for the biological entity used in the cell annotation."
+        }
       }
     }
   },


### PR DESCRIPTION
Adding missing CAP field.  Note - an actual list here becomes a comma separated list on flattening.

Fixes #110 