### PR TITLE
'negative_marker_gene_evidence' refactoring

### DIFF
--- a/BICAN_extension.json
+++ b/BICAN_extension.json
@@ -84,6 +84,14 @@
           "items": {
             "$ref": "#/definitions/Cell"
           }
+        },
+        "negative_marker_gene_evidence": {
+          "description": "List of names of genes, the absence of expression of which is explicitly used as evidence for this cell annotation. Each gene MUST be included in the matrix of the AnnData/Seurat file.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Gene names explicitly used as evidence, which MUST be in the matrix of the AnnData/Seurat file"
+          }
         }
       }
     }

--- a/general_schema.json
+++ b/general_schema.json
@@ -141,14 +141,6 @@
             "description": "Gene names explicitly used as evidence, which MUST be in the matrix of the AnnData/Seurat file"
           }
         },
-        "negative_marker_gene_evidence": {
-          "description": "List of names of genes, the absence of expression of which is explicitly used as evidence for this cell annotation. Each gene MUST be included in the matrix of the AnnData/Seurat file.",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "description": "Gene names explicitly used as evidence, which MUST be in the matrix of the AnnData/Seurat file"
-          }
-        },
         "synonyms": {
           "description": "This field denotes any free-text term of a biological entity which the author associates as synonymous with the biological entity listed in the field 'cell_label'.\nIn the case whereby no synonyms exist, the authors MAY leave this as blank, which is encoded as 'NA'. However, this field is NOT OPTIONAL.",
           "type": "array",


### PR DESCRIPTION
Requested by Evan via email;

> (1) Could we remove "negative markers" from the general schema? CAP doesn't use it, and therefore it shouldn't be in the CAP extension.